### PR TITLE
Implement checksum verification for updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ colorama
 requests
 toml
 certifi
+hashlib


### PR DESCRIPTION
Implement checksum verification for updates.

* **Scripts/Core/Update.py**
  - Add `calculate_checksum` method to calculate the checksum of a file using SHA-256.
  - Add `verify_checksum` method to verify the checksum of a file against a given checksum.
  - Add `get_checksum_from_release` method to fetch the checksum from the release metadata.
  - Modify `perform_update` method to include checksum verification before applying the update.
  - Update `perform_update` method to call `get_checksum_from_release` and `verify_checksum`.

* **requirements.txt**
  - Add `hashlib` to the list of dependencies.

